### PR TITLE
Upgrade geotools to 26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.datasyslab</groupId>
     <artifactId>geotools-wrapper</artifactId>
-    <version>1.1.0-25.2</version>
+    <version>1.1.0-26.1</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>GeoTools wrapper for Apache Sedona</description>
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dependency.scope>provided</dependency.scope>
-        <geotools.version>25.2</geotools.version>
+        <geotools.version>26.1</geotools.version>
         <geotools.scope>compile</geotools.scope>
         <jts.version>1.18.0</jts.version>
         <jts2geojson.version>0.14.3</jts2geojson.version>


### PR DESCRIPTION
This patch upgrades geotools to version 26.1.

Version 26.1 adds support for geotiff-compression codecs not supported by 25.1.

This patch has been built and verified with Apache Sedona 1.1.0